### PR TITLE
Fix: poetry modern installation failure

### DIFF
--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -42,10 +42,11 @@ jobs:
           key: {% raw %}venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,6 +140,7 @@ jobs:
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -139,6 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
+      - name: Install poetry
+        run: python -m pip install poetry==1.4
+
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -139,13 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
-      - name: Install poetry
-        run: python -m pip install poetry==1.4
-
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
-          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -45,8 +45,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,8 +140,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -178,8 +178,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -299,7 +300,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3
@@ -386,8 +389,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -302,7 +302,6 @@ jobs:
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
-          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -175,10 +175,11 @@ jobs:
           key: {% raw %}venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -382,10 +383,11 @@ jobs:
           key: {% raw %}venv-release-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
@@ -490,10 +492,11 @@ jobs:
           key: {% raw %}venv-release-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without test,pyinstaller

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -492,7 +492,7 @@ jobs:
           key: {% raw %}venv-release-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.4
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -79,8 +79,9 @@ jobs:
 
       - name: Install and configure poetry
         run: |
-          python -m pip install poetry
+          python -m pip install poetry==1.4
           poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3


### PR DESCRIPTION
Poetry v1.4 includes a new default installation method which currently fails for us.

Update poetry versions to 1.4 (except that used for building linux executables) and turn off the modern installation method.

Update linux poetry version when centOS docker image is updated.

Closes #21 