### PR TITLE
Fix: update ubuntu runner

### DIFF
--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -450,7 +450,7 @@ jobs:
 
   build-documentation:
     needs: release-github-PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -498,7 +498,8 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+             poetry config virtualenvs.in-project true
              poetry config installer.modern-installation false
 
       - name: Install dependencies


### PR DESCRIPTION
Ubuntu runner used for build documentation segment of release workflow was `ubuntu-18.04`.

This version of the runner was no longer supported by gha.

Have updated the runner used to `ubuntu-latest` in line with the rest of the workflow(s).

Closes #30 