### PR TITLE
Remove Python 3.7, add Python 3.11, Update CentOS image

### DIFF
--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -127,7 +127,7 @@ jobs:
   build-executables-linux:
     runs-on: ubuntu-latest
     container:
-      image: aplowman/centos7-poetry
+      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -142,6 +142,7 @@ jobs:
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -127,7 +127,7 @@ jobs:
   build-executables-linux:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
+      image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -499,7 +499,8 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+             poetry config virtualenvs.in-project true
              poetry config installer.modern-installation false
 
       - name: Install dependencies

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -451,7 +451,7 @@ jobs:
 
   build-documentation:
     needs: release-github-PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bump-version
     container:
-      image: aplowman/centos7-poetry
+      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -302,6 +302,7 @@ jobs:
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bump-version
     container:
-      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
+      image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -101,7 +101,7 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
+      image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -101,7 +101,7 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     container:
-      image: aplowman/centos7-poetry
+      image: ghcr.io/hpcflow/centos7-poetry:py3.10.9_po1.4.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -114,7 +114,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -58,10 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
Remove support (and testing) for Python 3.7, add support (and testing) for Python 3.11.

Update CentOS image used. Workflows use version tagged latest to build pyinstaller Linux version.

Closes #9