### PR TITLE
feat: test-pre-python GHA for testing on latest python pre-release version.

### DIFF
--- a/.github/workflows/test_pre_python.yml.in
+++ b/.github/workflows/test_pre_python.yml.in
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          allow-prereleases: true
 
       - name: Install and configure poetry
         run: |

--- a/.github/workflows/test_pre_python.yml.in
+++ b/.github/workflows/test_pre_python.yml.in
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "latest"
+          - "3.12-dev"
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/test_pre_python.yml.in
+++ b/.github/workflows/test_pre_python.yml.in
@@ -1,0 +1,49 @@
+name: test-pre-python
+concurrency:
+  | # e.g. don't run simultaneously on the same branch (since we may commit to that branch)
+  {% raw %}ci-${{ format('{0}github.head_ref', 'refs/heads') || github.ref }}{% endraw %}
+
+on:
+  workflow_dispatch: # manual invocation
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "latest"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: {% raw %}${{ github.ref }}{% endraw %}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+
+      - name: Install and configure poetry
+        run: |
+          python -m pip install poetry==1.4
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
+
+      - name: Cache the virtualenv
+        uses: actions/cache@v3
+        with:
+          path: ./.venv
+          key: {% raw %}${{ runner.os }}-test-${{ matrix.python-version }}-venv-${{ hashFiles('**/poetry.lock') }}{% endraw %}
+
+      - name: Install dependencies
+        run: |
+          poetry install --without dev,pyinstaller
+
+      - name: Run tests
+        run: |
+          poetry run python -m pytest {{ pytest_args }}


### PR DESCRIPTION
Same as test workflow, but not involving CentOS.
Selects latest pre-release version to test on.
Manually invoked.