### PR TITLE
gets make_vers_switcher.py from github.head_ref using curl

### DIFF
--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -557,6 +557,7 @@ jobs:
 
       - name: Update doc version switcher
         run: |
+          curl https://raw.githubusercontent.com/{{ org }}/{{ repo }}/${{ github.head_ref }}/docs/make_vers_switcher.py --output docs/make_vers_switcher.py
           python docs/make_vers_switcher.py
 
       - name: Push changes


### PR DESCRIPTION
The script `make_vers_switcher.py` in the docs website is replaced by the script in the `github.head_ref`, and should get pushed along with the new versions.
There should be no need to delete the script from the individual docs repos,  and a copy of the used make_vers_switcher script is kept on each push, which could also help with debugging.